### PR TITLE
Updated Cargo.toml for 2fd/rust-regex-playground#1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,27 +9,27 @@ homepage = "https://2fd.github.io/rust-regex-playground"
 repository = "https://github.com/2fd/rust-regex-playground"
 
 [dependencies]
-toml = "0.5.1"
-regex = "1.1.7"
-regex-syntax = "0.6.7"
-js-sys = "0.3.22"
+toml = "0.5.8"
+regex = "1.5.4"
+regex-syntax = "0.6.25"
+js-sys = "0.3.55"
 wasm-bindgen = "0.2"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
-console_error_panic_hook = { version = "0.1.1", optional = true }
+console_error_panic_hook = { version = "0.1.7", optional = true }
 
 # `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
 # compared to the default allocator's ~10K. It is slower than the default
 # allocator, however.
 #
 # Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
-wee_alloc = { version = "0.4.2", optional = true }
+wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.2"
+wasm-bindgen-test = "0.3.28"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
Related issue: 2fd/rust-regex-playground#1

## Changes

* regex = "1.5.4"
* updated all other deps to the latest
* project builds, untested

## Testing

I have no idea how WASM works and and not familiar with React, so can't really test. The project builds with a single warning:
```
warning: function is never used: `get_metadata`
  --> src/utils.rs:20:8
   |
20 | pub fn get_metadata() -> JsValue {
   |        ^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: 1 warning emitted
```
